### PR TITLE
DSLCompiler: Add the project directory to improve static analysis

### DIFF
--- a/hadoop-plugin/src/integTest/groovy/com/linkedin/gradle/BuildHadoopZips.groovy
+++ b/hadoop-plugin/src/integTest/groovy/com/linkedin/gradle/BuildHadoopZips.groovy
@@ -48,7 +48,9 @@ class BuildHadoopZips extends Specification {
         azkabanZip.exists()
         def zipFileContents = new ZipFile(azkabanZip)
         zipFileContents.getEntry('build.gradle') != null
-        zipFileContents.getEntry('buildMetadata.json') != null
+        def buildMetadataJson = zipFileContents.getEntry('buildMetadata.json')
+        buildMetadataJson != null
+        new Scanner(zipFileContents.getInputStream(buildMetadataJson)).useDelimiter("\\A").next().contains("\"projectDirectory\": \"\"")
         zipFileContents.getEntry("${projectName}-${version}-sources.zip") != null
     }
 }

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/ScmMetadataContainer.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/ScmMetadataContainer.groovy
@@ -32,6 +32,7 @@ class ScmMetadataContainer {
   UserMetadata userMetadata;
   SvnMetadata svnMetadata;
   ScmType scmType;
+  String projectDirectory;
 
   /**
    * Constructor for ScmMetadata.
@@ -40,7 +41,7 @@ class ScmMetadataContainer {
    * @param svnMetadata The Subversion metadata
    * @param userMetadata The user metadata
    */
-  ScmMetadataContainer(GitMetadata gitMetadata, SvnMetadata svnMetadata, UserMetadata userMetadata) {
+  ScmMetadataContainer(GitMetadata gitMetadata, SvnMetadata svnMetadata, UserMetadata userMetadata, String projectDirectory) {
     this.userMetadata = userMetadata;
 
     if (gitMetadata.isGitRepo) {
@@ -57,6 +58,7 @@ class ScmMetadataContainer {
 
     // Set scmType to NONE if we did not find either a Git or SVN repository.
     this.scmType = (this.scmType != null) ? this.scmType : ScmType.NONE;
+    this.projectDirectory = projectDirectory;
   }
 
   /**

--- a/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/ScmPlugin.groovy
+++ b/hadoop-plugin/src/main/groovy/com/linkedin/gradle/scm/ScmPlugin.groovy
@@ -22,7 +22,10 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.api.tasks.bundling.Zip
+
+import java.nio.file.Path
+import java.nio.file.Paths;
 
 /**
  * ScmPlugin implements features that generate source control management (scm) metadata, in
@@ -91,6 +94,17 @@ class ScmPlugin implements Plugin<Project> {
   }
 
   /**
+   * Returns the subproject directory relative to the root directory. It helps with runtime/static analysis for
+   * migrations
+   * @return The relativized path to the project. E.g. "subproject_dir_parent/subproject_dir"
+   */
+  private static String getRelativeProjectDirectory(Project p) {
+    Path rootProjectDirectory = Paths.get(p.getRootDir().getAbsolutePath());
+    Path projectDirectory = Paths.get(p.getProjectDir().getAbsolutePath());
+    return rootProjectDirectory.relativize(projectDirectory).toString();
+  }
+
+  /**
    * Builds and populates the SCM metadata using the various factory methods in this class.
    * Subclasses can override this method if they want to customize how the SCM metadata is built.
    *
@@ -106,7 +120,7 @@ class ScmPlugin implements Plugin<Project> {
 
     SvnMetadata svn = createSvnMetadata();
     svn.setMetadataProperties(project);
-    return createScmMetadataContainer(git, svn, user);
+    return createScmMetadataContainer(git, svn, user, getRelativeProjectDirectory(project));
   }
 
   /**
@@ -138,8 +152,9 @@ class ScmPlugin implements Plugin<Project> {
    * @param userMetadata The user metadata
    * @return A new ScmMetadataContainer instance
    */
-  ScmMetadataContainer createScmMetadataContainer(GitMetadata gitMetadata, SvnMetadata svnMetadata, UserMetadata userMetadata) {
-    return new ScmMetadataContainer(gitMetadata, svnMetadata, userMetadata);
+  ScmMetadataContainer createScmMetadataContainer(
+      GitMetadata gitMetadata, SvnMetadata svnMetadata, UserMetadata userMetadata, String projectDirectory) {
+    return new ScmMetadataContainer(gitMetadata, svnMetadata, userMetadata, projectDirectory);
   }
 
   /**


### PR DESCRIPTION
Why: helps with LinkedIn's internal migration

What changed: added a projectDirectory which helps us identify the subproject in a MP

Tests performed: modified unit tests